### PR TITLE
Revert "Merge pull request #10 from isaqb-org/fine_tuning"

### DIFF
--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -1,6 +1,6 @@
 include::config/setup.adoc[]
 
-= image:isaqb-logo.jpg[width=150]Certified Professional for Software Architecture^(R)^ - Expert Level
+= image:isaqb-logo.jpg[width=150]Certified Professional for Software Architecture^(R)^ (CPSA)
 Expert Level
 
 The international Software Architecture Qualification Board (link:https://isaqb.org[iSAQB]) defines curricula on several levels for software architects.


### PR DESCRIPTION
The previous change was unnecessary and doubled "Expert Level" in the heading of the index page. Now it's back to the old format and coherent with all other curricula.