### PR TITLE
update deprecated actions/upload-artifac

### DIFF
--- a/.github/workflows/build_pr.yml
+++ b/.github/workflows/build_pr.yml
@@ -34,7 +34,7 @@ jobs:
           gradle-version: wrapper
           arguments: buildDocs
       - name: Upload Build Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: curriculum files (PDF and HTML)
           path: |


### PR DESCRIPTION
v3 of actions/upload-artifac is deprectated

see https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/