### PR TITLE
improve overview page

### DIFF
--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -8,22 +8,44 @@ The international Software Architecture Qualification Board (link:https://isaqb.
 The terminology used in the iSAQB curricula can be found as a (freely available) ebook, published on https://leanpub.com/isaqbglossary/read[Leanpub].
 
 The regulations and criteria of the Expert Level are currently maintained and published in both English (EN) and German (DE).
-Maintainers and volunteer reviewers collaborate on GitHub to improve those documents.
+Maintainers and volunteer reviewers collaborate on https://github.com/isaqb-org/examination-expert[GitHub] to improve those documents.
+
+== English
 
 [cols="<,<"]
 |===
-| German | English
+| Document | Versions
 
-| link:examination-regulations-de.pdf[Prüfungsordnung (PDF)]
-| link:examination-regulations-en.pdf[Examination Regulations (PDF)]
+| Examination Regulations
+| link:examination-regulations-en.html[HTML],  link:examination-regulations-en.pdf[PDF]
 
-| link:examination-criteria-de.pdf[Kriterien (PDF)]
-| link:examination-criteria-en.pdf[Examination Criteria (PDF)]
+| Roadmap Template
+| link:iSAQB_CPSA_Expert_Level_Template_Roadmap_EN.docx[DOCX]
 
-| link:iSAQB_CPSA_Expert_Level_Template_Roadmap_DE.docx[Vorlage für eine Roadmap (DOCX)]
-| link:iSAQB_CPSA_Expert_Level_Template_Roadmap_EN.docx[Roadmap Template (DOCX)]
+| Field Report Template
+| link:iSAQB_CPSA_Expert_Level_Field_Report_EN.docx[DOCX]
 
-| link:iSAQB_CPSA_Expert_Level_Field_Report_DE.docx[Erfahrungsbericht zum Expert Level (DOCX)]
-| link:iSAQB_CPSA_Expert_Level_Field_Report_EN.docx[Field Report Expert Level (DOCX)]
+| Criteria
+| link:examination-criteria-en.html[HTML],  link:examination-criteria-en.pdf[PDF]
+
+|===
+
+== German
+
+[cols="<,<"]
+|===
+| Document | Versions
+
+| Prüfungsordnung
+| link:examination-regulations-de.html[HTML],  link:examination-regulations-de.pdf[PDF]
+
+| Vorlage für die Roadmap
+| link:iSAQB_CPSA_Expert_Level_Template_Roadmap_DE.docx[DOCX]
+
+| Vorlage für Erfahrungsbericht
+| link:iSAQB_CPSA_Expert_Level_Field_Report_DE.docx[DOCX]
+
+| Kriterien
+| link:examination-criteria-de.html[HTML],  link:examination-criteria-de.pdf[PDF]
 
 |===


### PR DESCRIPTION
I have improved the overview page that will be linked in [public.isaqb.org](https://public.isaqb.org/)

English and German documents are now in different tables.

The examination regulation and the criteria are also available as HTML documents.

# Before
![grafik](https://github.com/user-attachments/assets/ec5bffb0-f34f-4d3b-8923-4408c3ec4521)

# After
![grafik](https://github.com/user-attachments/assets/fa064b84-c1bb-45d6-a874-f2e5627592ec)
